### PR TITLE
Request Materializer instead of the over-specific ActorMaterializer

### DIFF
--- a/src/main/scala/org/eiennohito/grpc/stream/ServerCallBuilder.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/ServerCallBuilder.scala
@@ -16,7 +16,7 @@
 
 package org.eiennohito.grpc.stream
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc._
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
   * @since 2016/04/28
   */
 class ServerCallBuilder[Request: ClassTag, Reply](md: MethodDescriptor[Request, Reply]) extends StrictLogging {
-  def handleWith[T](flow: CallMetadata => Future[Flow[Request, Reply, T]])(implicit mat: ActorMaterializer, ec: ExecutionContext) = {
+  def handleWith[T](flow: CallMetadata => Future[Flow[Request, Reply, T]])(implicit mat: Materializer, ec: ExecutionContext) = {
     val handler: ServerCallHandler[Request, Reply] = new ServerAkkaStreamHandler[Request, Reply](flow)
     handler
   }

--- a/src/main/scala/org/eiennohito/grpc/stream/client/AStreamClient.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/client/AStreamClient.scala
@@ -18,7 +18,7 @@ package org.eiennohito.grpc.stream.client
 
 import java.util.UUID
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.{Done, NotUsed}
 import akka.stream.scaladsl.{Flow, Source}
 import io.grpc.MethodDescriptor.MethodType
@@ -48,8 +48,8 @@ trait AStreamCall[T, R] {
 
 trait UnaryCall[T, R] extends AStreamCall[T, R] {
   def withOpts(copts: CallOptions): UnaryCall[T, R]
-  def apply(v: T)(implicit amat: ActorMaterializer): Future[R]
-  def func(implicit amat: ActorMaterializer): T => Future[R] = apply
+  def apply(v: T)(implicit mat: Materializer): Future[R]
+  def func(implicit mat: Materializer): T => Future[R] = apply
 }
 
 trait OneInStreamOutCall[T, R] extends (T => Source[R, GrpcCallStatus]) with AStreamCall[T, R] {

--- a/src/main/scala/org/eiennohito/grpc/stream/impl/ServerAkkaStreamHandler.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/impl/ServerAkkaStreamHandler.scala
@@ -3,7 +3,7 @@ package org.eiennohito.grpc.stream.impl
 import akka.actor.ActorRef
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.stage.{AsyncCallback, GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
-import akka.stream.{ActorMaterializer, Attributes, Inlet, Outlet, SinkShape, SourceShape}
+import akka.stream.{Materializer, Attributes, Inlet, Outlet, SinkShape, SourceShape}
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.{Context, Metadata, ServerCall, ServerCallHandler, Status}
 import org.eiennohito.grpc.stream.GrpcStreaming
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
   * @author eiennohito
   * @since 2016/10/27
   */
-class ServerAkkaStreamHandler[Req: ClassTag, Resp](handler: GrpcStreaming.ServerHandler[Req, Resp, _])(implicit ec: ExecutionContext, amat: ActorMaterializer)
+class ServerAkkaStreamHandler[Req: ClassTag, Resp](handler: GrpcStreaming.ServerHandler[Req, Resp, _])(implicit ec: ExecutionContext, mat: Materializer)
   extends ServerCallHandler[Req, Resp] {
   override def startCall(call: ServerCall[Req, Resp], headers: Metadata) = {
     new ServerAkkaHandler(call, headers, handler)
@@ -138,7 +138,7 @@ class ServerAkkaHandler[Req: ClassTag, Resp](
   headers: Metadata,
   handler: GrpcStreaming.ServerHandler[Req, Resp, _])(
   implicit ec: ExecutionContext,
-  amat: ActorMaterializer
+  mat: Materializer
 ) extends ServerCall.Listener[Req] with StrictLogging {
 
   private [this] val inputPromise = Promise[AsyncCallback[Any]]()

--- a/src/main/scala/org/eiennohito/grpc/stream/impl/client/UnaryCallImpl.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/impl/client/UnaryCallImpl.scala
@@ -1,6 +1,6 @@
 package org.eiennohito.grpc.stream.impl.client
 
-import akka.stream.{ActorMaterializer, Fusing}
+import akka.stream.{Materializer, Fusing}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.{CallOptions, Channel, MethodDescriptor}
@@ -28,7 +28,7 @@ class UnaryCallImpl[Request, Reply](
     Flow.fromGraph(Fusing.aggressive(flow))
   }
 
-  override def apply(v1: Request)(implicit amat: ActorMaterializer) = {
+  override def apply(v1: Request)(implicit mat: Materializer) = {
     Source.single(v1).via(flow).runWith(Sink.head)
   }
 }

--- a/src/main/scala/org/eiennohito/grpc/stream/server/ServiceBuilder.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/server/ServiceBuilder.scala
@@ -16,7 +16,7 @@
 
 package org.eiennohito.grpc.stream.server
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import com.trueaccord.scalapb.grpc.ServiceCompanion
 import io.grpc.ServerServiceDefinition.Builder
@@ -52,16 +52,16 @@ object ServiceBuilder {
 case class CallMetadata(ctx: Context, metadata: Metadata)
 
 class ServiceDefBuilder[T, R](bldr: ServerServiceDefinition.Builder, mdesc: MethodDescriptor[T, R], scb: ServerCallBuilder[T, R]) {
-  def handleSingle(fn: T => Future[R])(implicit mat: ActorMaterializer, ec: ExecutionContext): Unit = {
+  def handleSingle(fn: T => Future[R])(implicit mat: Materializer, ec: ExecutionContext): Unit = {
     val flow = Flow[T].mapAsync(1)(fn)
     handleWith(flow)
   }
 
-  def handleWith[Mat](flow: Flow[T, R, Mat])(implicit mat: ActorMaterializer, ec: ExecutionContext): Unit = {
+  def handleWith[Mat](flow: Flow[T, R, Mat])(implicit mat: Materializer, ec: ExecutionContext): Unit = {
     handleWith(_ => Future.successful(flow))
   }
 
-  def handleWith[Mat](flowFactory: CallMetadata => Future[Flow[T, R, Mat]])(implicit mat: ActorMaterializer, ec: ExecutionContext): Unit = {
+  def handleWith[Mat](flowFactory: CallMetadata => Future[Flow[T, R, Mat]])(implicit mat: Materializer, ec: ExecutionContext): Unit = {
     val sch = scb.handleWith(flowFactory)
     bldr.addMethod(mdesc, sch)
   }

--- a/tests/src/test/scala/org/eiennohito/grpc/GrpcAkkaSpec.scala
+++ b/tests/src/test/scala/org/eiennohito/grpc/GrpcAkkaSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
   */
 abstract class GrpcAkkaSpec extends TestKit(ActorSystem()) with GrpcServerClientSpec with LoneElement {
   implicit def ec: ExecutionContext = system.dispatcher
-  implicit lazy val amat = ActorMaterializer.create(system)
+  implicit lazy val mat = ActorMaterializer.create(system)
 
   override protected def afterAll() = {
     super.afterAll()

--- a/tests/src/test/scala/org/eiennohito/grpc/GrpcBothSidesBackpressure.scala
+++ b/tests/src/test/scala/org/eiennohito/grpc/GrpcBothSidesBackpressure.scala
@@ -35,7 +35,7 @@ import scala.concurrent.duration._
   */
 class GrpcBothSidesBackpressure extends TestKit(ActorSystem()) with GrpcServerClientSpec {
 
-  implicit lazy val amat = ActorMaterializer.create(system)
+  implicit lazy val mat = ActorMaterializer.create(system)
   implicit def ec: ExecutionContext = system.dispatcher
 
   override def init = { b =>

--- a/tests/src/test/scala/org/eiennohito/grpc/GrpcServerAkkaStreamSpec.scala
+++ b/tests/src/test/scala/org/eiennohito/grpc/GrpcServerAkkaStreamSpec.scala
@@ -18,7 +18,7 @@ package org.eiennohito.grpc
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.{Flow, Source}
 import akka.testkit.TestKit
 import io.grpc.{MethodDescriptor, ServerServiceDefinition}
@@ -64,7 +64,7 @@ object AkkaServer {
     Flow[HelloRequestStream].flatMapConcat(r => Source((0 until r.number).map { i => HelloReply(s"Hi, ${r.name} #$i")}))
   }
 
-  def make(implicit mat: ActorMaterializer, ec: ExecutionContext): ServerServiceDefinition = {
+  def make(implicit mat: Materializer, ec: ExecutionContext): ServerServiceDefinition = {
     val names = GreeterGrpc.METHOD_SAY_HELLO.getFullMethodName.split('/')
     val bldr = ServerServiceDefinition.builder(names(0))
     val bld2 = ServiceBuilder(bldr)


### PR DESCRIPTION
Changes references of `ActorMaterializer` to `Materializer` in parameter type definitions

Fixes #2.