### PR TITLE
Drain GrpcClientHandler buffer before completeStage

### DIFF
--- a/src/main/scala/org/eiennohito/grpc/stream/impl/client/GrpcClientHandler.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/impl/client/GrpcClientHandler.scala
@@ -101,6 +101,7 @@ class GrpcClientHandler[Req, Resp](
             completeStage()
           } else {
             isCompleted = true
+            cancel(in)
           }
         } else {
           val ex = ScalaMetadata.get(m, ScalaMetadata.ScalaException) match {

--- a/src/main/scala/org/eiennohito/grpc/stream/impl/client/GrpcClientHandler.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/impl/client/GrpcClientHandler.scala
@@ -39,6 +39,7 @@ class GrpcClientHandler[Req, Resp](
       private val params = inheritedAttributes.get(Attributes.InputBuffer(8, 16))
       private val buffer = new mutable.Queue[Resp]()
       private var inFlight = 0
+      private var isCompleted = false
 
       private def request(): Unit = {
         if (inFlight < params.initial && buffer.size < params.initial) {
@@ -59,6 +60,9 @@ class GrpcClientHandler[Req, Resp](
       override def onPull(): Unit = {
         if (buffer.nonEmpty) {
           push(out, buffer.dequeue())
+        } else if (isCompleted) {
+          cmpl.success(Done)
+          completeStage()
         }
         request()
       }
@@ -92,8 +96,12 @@ class GrpcClientHandler[Req, Resp](
       private def handleClose(t: Status, m: Metadata) = {
         trls.success(m)
         if (t.isOk) {
-          cmpl.success(Done)
-          completeStage()
+          if (buffer.isEmpty) {
+            cmpl.success(Done)
+            completeStage()
+          } else {
+            isCompleted = true
+          }
         } else {
           val ex = ScalaMetadata.get(m, ScalaMetadata.ScalaException) match {
             case None => t.asException()


### PR DESCRIPTION
When `onClose` is called, there might still be messages in the stage's internal `buffer`.
These changes ensure, the `buffer` is drained before calling `completeStage`.

Fixes #3.