### PR TITLE
Update dependencies and cross-compile to Scala 2.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
   - 2.11.8
+  - 2.12.1
 jdk:
   - oraclejdk8
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@
 lazy val defaults = Def.settings(
   organization := "org.eiennohito",
   version := "0.1-SNAPSHOT",
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.11.8")
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
 
 lazy val coreDeps = Def.settings(
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.4.11",
+    "com.typesafe.akka" %% "akka-stream" % "2.4.16",
     "io.grpc" % "grpc-core" % grpcVersion,
     "io.grpc" % "grpc-stub" % grpcVersion,
     "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % scalaPbVersion,
@@ -27,18 +27,18 @@ lazy val `grpc-tests` =
     name := "grpc-akka-tests",
     libraryDependencies ++= Seq(
       "io.grpc" % "grpc-netty" % grpcVersion,
-      "org.slf4j" % "jul-to-slf4j" % "1.7.21",
-      "ch.qos.logback" % "logback-classic" % "1.1.7" % Test,
-      "com.typesafe.akka" %% "akka-stream-testkit" % "2.4.11" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.0" % Test,
-      "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % Test
+      "org.slf4j" % "jul-to-slf4j" % "1.7.22",
+      "ch.qos.logback" % "logback-classic" % "1.1.9" % Test,
+      "com.typesafe.akka" %% "akka-stream-testkit" % "2.4.16" % Test,
+      "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+      "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
     )
   )
   .dependsOn(`grpc-streaming`)
 
 
-lazy val scalaPbVersion = "0.5.43"
-lazy val grpcVersion = "1.0.1"
+lazy val scalaPbVersion = "0.5.47"
+lazy val grpcVersion = "1.0.3"
 
 def pbScala(): Seq[Setting[_]] = {
   Def.settings(
@@ -47,7 +47,7 @@ def pbScala(): Seq[Setting[_]] = {
       PB.gens.java -> (sourceManaged in Compile).value
     ),
     libraryDependencies ++= Seq(
-      "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.5.43" % "protobuf"
+      "com.trueaccord.scalapb" %% "scalapb-runtime" % scalaPbVersion % "protobuf"
     )
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-val scalaPbVersion = "0.5.43"
+val scalaPbVersion = "0.5.47"
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.1")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.3")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % scalaPbVersion
 


### PR DESCRIPTION
Updates all dependencies to their latest versions. In particular, updates ScalaPB to the versions currently in [their website](https://scalapb.github.io/). Also adds cross-compilation to Scala 2.12.
