### PR TITLE
Update ScalaPB and dependencies to their latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@
 lazy val defaults = Def.settings(
   organization := "org.eiennohito",
   version := "0.1-SNAPSHOT",
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.11.8", "2.12.1")
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.11", "2.12.4")
 )
 
 lazy val coreDeps = Def.settings(
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.4.16",
+    "com.typesafe.akka" %% "akka-stream" % "2.5.6",
     "io.grpc" % "grpc-core" % grpcVersion,
     "io.grpc" % "grpc-stub" % grpcVersion,
     "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % scalaPbVersion,
@@ -27,18 +27,18 @@ lazy val `grpc-tests` =
     name := "grpc-akka-tests",
     libraryDependencies ++= Seq(
       "io.grpc" % "grpc-netty" % grpcVersion,
-      "org.slf4j" % "jul-to-slf4j" % "1.7.22",
-      "ch.qos.logback" % "logback-classic" % "1.1.9" % Test,
-      "com.typesafe.akka" %% "akka-stream-testkit" % "2.4.16" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.1" % Test,
-      "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
+      "org.slf4j" % "jul-to-slf4j" % "1.7.25",
+      "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
+      "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.6" % Test,
+      "org.scalatest" %% "scalatest" % "3.0.4" % Test,
+      "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test
     )
   )
   .dependsOn(`grpc-streaming`)
 
 
-lazy val scalaPbVersion = "0.6.1"
-lazy val grpcVersion = "1.5.0"
+lazy val scalaPbVersion = "0.6.6"
+lazy val grpcVersion = "1.6.1"
 
 def pbScala(): Seq[Setting[_]] = {
   Def.settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-val scalaPbVersion = "0.6.1"
+val scalaPbVersion = "0.6.6"
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.11")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % scalaPbVersion
-

--- a/src/main/scala/org/eiennohito/grpc/stream/impl/client/UnaryCallImpl.scala
+++ b/src/main/scala/org/eiennohito/grpc/stream/impl/client/UnaryCallImpl.scala
@@ -1,6 +1,6 @@
 package org.eiennohito.grpc.stream.impl.client
 
-import akka.stream.{Materializer, Fusing}
+import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.{CallOptions, Channel, MethodDescriptor}
@@ -21,11 +21,10 @@ class UnaryCallImpl[Request, Reply](
   }
 
   override val flow: Flow[Request, Reply, GrpcCallStatus] = {
-    val flow = Flow[Request]
+    Flow[Request]
       .take(1)
       .viaMat(Flow.fromGraph(new GrpcClientHandler[Request, Reply](chan, md, opts)))(Keep.right)
       .take(1)
-    Flow.fromGraph(Fusing.aggressive(flow))
   }
 
   override def apply(v1: Request)(implicit mat: Materializer) = {


### PR DESCRIPTION
Updates all dependencies to their latest versions. In particular, updates ScalaPB to the versions currently in their website and Akka to version 2.5.

The only real change in the code was the removal of explicit fusing in streams, since Akka now [always fuses stages when it can](https://doc.akka.io/docs/akka/2.5/scala/project/migration-guide-2.4.x-2.5.x.html#removal-of-the-auto-fuse-setting).